### PR TITLE
Fix race condition in Lighthouse.

### DIFF
--- a/Lib/lighthouse/lighthouse.cpp
+++ b/Lib/lighthouse/lighthouse.cpp
@@ -148,6 +148,7 @@ Lighthouse::AuxRunEventLoop(Lighthouse *self) {
 }
 
 void Lighthouse::RunIdentifyObject() {
+  assert(std::this_thread::get_id() == mVideoThreadId);
   // Start recording. `mCamera` is in charge of stopping itself if `mTask` stops being `Task::IDENTIFY`.
   cv::Mat sourceImage;
   if (!mCamera.CaptureForIdentification(&mTask, sourceImage)) {
@@ -200,7 +201,7 @@ void Lighthouse::RunIdentifyObject() {
 }
 
 void Lighthouse::RunRecordObject() {
-  assert(std::this_thread::get_id() == mVideoThread.get_id());
+  assert(std::this_thread::get_id() == mVideoThreadId);
   // Start recording. `mCamera` is in charge of stopping itself if `mTask` stops being `Task::RECORD`.
   cv::Mat source;
   if (!mCamera.CaptureForRecord(&mTask, source)) {
@@ -225,7 +226,7 @@ void Lighthouse::RunRecordObject() {
 }
 
 void Lighthouse::RunEventLoop() {
-  assert(std::this_thread::get_id() == mVideoThread.get_id());
+  mVideoThreadId = std::this_thread::get_id();
   // Stamp of the latest message received.
   uint64_t stamp = 0;
   while (true) {

--- a/Lib/lighthouse/lighthouse.hpp
+++ b/Lib/lighthouse/lighthouse.hpp
@@ -103,6 +103,9 @@ private:
 
   // A thread designed to run all blocking camera/vision operations.
   std::thread mVideoThread;
+  // Id of the video thread. Use it only to check that you are on that thread.
+  std::thread::id mVideoThreadId;
+
   // Representation of the latest `Task` requested from the event loop.
   std::atomic_int mTask;
   // A stamp incremented each time we send a message to the event loop.


### PR DESCRIPTION
This race condition would (for good reasons) choke unit tests.