### PR TITLE
Splitting Continuous Integration builds

### DIFF
--- a/Lighthouse Camera.xcodeproj/xcshareddata/xcschemes/Lighthouse Camera Continuous Integration (Address Sanitizer).xcscheme
+++ b/Lighthouse Camera.xcodeproj/xcshareddata/xcschemes/Lighthouse Camera Continuous Integration (Address Sanitizer).xcscheme
@@ -26,8 +26,19 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      enableAddressSanitizer = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "63B98FE61E03F211000125CB"
+               BuildableName = "Lighthouse CameraTests.xctest"
+               BlueprintName = "Lighthouse CameraTests"
+               ReferencedContainer = "container:Lighthouse Camera.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
       <MacroExpansion>
          <BuildableReference
@@ -39,6 +50,11 @@
          </BuildableReference>
       </MacroExpansion>
       <AdditionalOptions>
+         <AdditionalOption
+            key = "NSZombieEnabled"
+            value = "YES"
+            isEnabled = "YES">
+         </AdditionalOption>
       </AdditionalOptions>
    </TestAction>
    <LaunchAction


### PR DESCRIPTION
We now have:
- one Address Sanitizer build (runs tests);
- one Thread Sanitizer build (runs tests);
- one non-instrumented build (doesn't run test, use this for distribution to testers).